### PR TITLE
fixed compilation issue due to deprecation warning using MSVC C++ 17

### DIFF
--- a/external/fmt/include/fmt/format.h
+++ b/external/fmt/include/fmt/format.h
@@ -48,6 +48,10 @@
 
 #include "core.h"
 
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)  // Disable deprecated function warnings
+#endif
+
 #ifndef FMT_BEGIN_DETAIL_NAMESPACE
 #  define FMT_BEGIN_DETAIL_NAMESPACE namespace detail {
 #  define FMT_END_DETAIL_NAMESPACE }


### PR DESCRIPTION
Does not compile right out of the box due to a deprecation warning in format.h in the fmt library. Both upgrading the fmt version and applying the solution proposed by CMake failed. The warning is related to the deprecation of stdext::checked_array_iterator (https://github.com/fmtlib/fmt/issues/3540).

Setting "Treat Warning as Errors" to "/No" can solve the issue but I went for `#pragma warning(disable : 4996)`. This way the solution compiles right after cloning.